### PR TITLE
Use symbol start/end to delimit builtin keywords

### DIFF
--- a/twig-mode.el
+++ b/twig-mode.el
@@ -207,11 +207,11 @@
                                     (twig-indenting-keywords)
                                     )
                            word-end)) (0 font-lock-keyword-face))
-     (,(rx-to-string `(and word-start
+     (,(rx-to-string `(and symbol-start
                            ,(append '(or)
                                     (twig-builtin-keywords)
                                     )
-                           word-end)) (0 font-lock-builtin-face))
+                           symbol-end)) (0 font-lock-builtin-face))
 
      (,(rx (or "{%" "%}" "{%-" "-%}")) (0 font-lock-function-name-face t))
      (,(rx (or "{{" "}}")) (0 font-lock-type-face t))


### PR DESCRIPTION
Using word start/end to delimit builtin keywords in the regular
expression causes, for example, both “is” and “is_something” to match on
the “is” part. Using symbol start/end will not match “is_something” and
leave it unhighlighted.
